### PR TITLE
Bug fix - Uart stucked after canceling a receive operation

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -236,6 +236,10 @@ static void MX_GPIO_Init(void)
 
 /* USER CODE BEGIN 4 */
 
+void uart_clear_overrun_flag (void){
+	huart1.Instance->ICR |= (1 << 3);
+}
+
 /* USER CODE END 4 */
 
 /**

--- a/Src/xmodem.c
+++ b/Src/xmodem.c
@@ -19,6 +19,9 @@ static uint16_t xmodem_calc_crc(uint8_t *data, uint16_t length);
 static xmodem_status xmodem_handle_packet(uint8_t size);
 static xmodem_status xmodem_error_handler(uint8_t *error_number, uint8_t max_error_number);
 
+/* externs */
+extern void uart_clear_overrun_flag (void);
+
 /**
  * @brief   This function is the base of the Xmodem protocol.
  *          When we receive a header from UART, it decides what action it shall take.
@@ -102,6 +105,9 @@ void xmodem_receive(void)
         }
         break;
     }
+
+    /*Prevent an overrun error after stop/cancel in the middle of a pack transference*/
+    uart_clear_overrun_flag();
   }
 }
 


### PR DESCRIPTION
I created this code fix after observing that UART got stuck after a stop/cancel in the middle of a receive operation.